### PR TITLE
fix: Add error handling for invalid params

### DIFF
--- a/lib/jrpc/router.ex
+++ b/lib/jrpc/router.ex
@@ -67,7 +67,7 @@ defmodule JRPC.Router do
         context
     end
   rescue
-    UndefinedFunctionError ->
+    [UndefinedFunctionError, FunctionClauseError] ->
       add_error(ctx, %JRPC.InvalidParamsError{})
 
     error ->

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -112,8 +112,16 @@ defmodule JRPC.RouterTest do
       assert "Method not found" = error.message
     end
 
-    test "returns a InvalidParams error when invalid params" do
+    test "returns a InvalidParams error with invalid params" do
       rpc = Example.rpc("ex.none", 10)
+
+      assert %Response{result: nil, error: error} =
+               Example.Router.handle(rpc)
+
+      assert -32_602 = error.code
+      assert "Invalid params" = error.message
+
+      rpc = Example.rpc("ex.map", %{"key" => "invalid"})
 
       assert %Response{result: nil, error: error} =
                Example.Router.handle(rpc)


### PR DESCRIPTION
Functions called with incorrect arity raise a `UndefinedFunctionError` while functions called with the correct arity but not matching a clause (due to params mismatch) will raise a `FunctionClauseError`.

Both of these scenarios should raise a `JRPC.InvalidParamsError` when dispatching since this only occurs after a route has been matched.